### PR TITLE
Update connect-your-database.mdx

### DIFF
--- a/pages/data/connect-your-database.mdx
+++ b/pages/data/connect-your-database.mdx
@@ -32,6 +32,8 @@ const resp = await fetch(`${BASE_URL}/api/v1/connections`, {
             database: '...',
             user: '...',
             password: '...',
+            port: ..., // optional, number, necessary for SSH
+            ssl: true, // optional, boolean, necessary for SSH
         },
     }),
 });


### PR DESCRIPTION
**Description**
Adds two optional (but necessary for SSH) connection credentials to the code example for making connections.

**Reason**
We just had a customer who could potentially have figured things out for themselves if they'd known the SSL option was required for SSH connections, but didn't, and mentioned it wasn't in the docs.

**Acceptance Criteria**
Agreement with me (and the customer) that yes, it should be in the docs. 😁 
