### PR TITLE
Updating databricks credentials to match what our API will accept

### DIFF
--- a/pages/data/credentials.mdx
+++ b/pages/data/credentials.mdx
@@ -38,10 +38,8 @@ credentials: {
 ```javascript
 type: 'databricks-jdbc',
 credentials: {
-  name: '...',
-  databricks_url: '...',
-  databricks_token: '...',
-  databricks_accept_policy: 'true',
+  url: '...',
+  token: '...',
 }
 ```
 


### PR DESCRIPTION
I just set up a databricks connection, and our docs do not accurately reflect the credential properties the API is looking for. It rejects a POST containing any/all of the following properties:
```
name
databricks_name
databricks_url
databricks_token
databricks_accept_policy
accept_policy
```
and only accepts:
```
url
token
```
... that said if you just use those two it works correctly. So this docs update should be fine.