### PR TITLE
Update Docs for Boilerplate Changes

### DIFF
--- a/pages/getting-started/install-starter-kit.mdx
+++ b/pages/getting-started/install-starter-kit.mdx
@@ -7,11 +7,19 @@ Here's what you need to do to get set up:
 <Steps>
 ### Delete the Example components
 
-You probably don't need a "Hello World" component or a "TextInput" component, and our starter kit includes a more robust Pie chart. So go ahead and delete the entire `example` directory in the `src/embeddable.com/components` directory.
+You probably don't need a "Hello World" component, and our starter kit includes a more robust Pie chart and Text Input. So go ahead and delete the entire `example` directory in the `src/embeddable.com/components` directory.
 
 ### Uncomment the starter kit
 
-Open `embeddable.config.ts` and uncomment the `componentLibraries` line (typically [line 14](https://github.com/embeddable-hq/embeddable-boilerplate/blob/eaa160b10f0199febcb70f0c251a94e303782b55/embeddable.config.ts#L14) if you haven't changed anything else). Save that file.
+Open `embeddable.config.ts` and uncomment the `componentLibraries` line (typically [line 17](https://github.com/embeddable-hq/embeddable-boilerplate/blob/eaa160b10f0199febcb70f0c251a94e303782b55/embeddable.config.ts#L17) if you haven't changed anything else). You will also need to delete the following line:
+
+```typescript
+  componentLibraries: [
+    { name: '@embeddable.com/vanilla-components', include: [] },
+  ],
+```
+
+If you're looking to only use _some_ of the starter kit, please see the comments in that file for more details. We recommend you use the entire library for now, but you can always remove components later. In either case, when you're done editing, save that file.
 
 ### Re-build or re-run the dev server
 


### PR DESCRIPTION
Changes are here: https://github.com/embeddable-hq/embeddable-boilerplate/pull/4

We found a way to use the vanilla container without throwing theme errors, thus no longer needing a separate example container.

Approve that PR first, then this one. 🙂