### PR TITLE
Update documentation to mention embed endpoint

### DIFF
--- a/pages/deployment/deployment-regions.mdx
+++ b/pages/deployment/deployment-regions.mdx
@@ -42,16 +42,16 @@ When [embedding](/deployment/embedding), you’ll also need to use the correct `
 ```js
 <script 
   type="module" 
-  src="https://api.<region>.embeddable.com/js/v1/">
+  src="https://embed.embeddable.com/js/v1/?region=<region>">
 </script>
 ```
 
-where `<region>` is one of `us` or `eu`.  E.g. for `US`:
+where `<region>` is one of `US` or `EU`.  E.g. for `US`:
 
 ```js
 <script 
   type="module" 
-  src="https://api.us.embeddable.com/js/v1/">
+  src="https://embed.embeddable.com/js/v1/?region=US">
 </script>
 ```
 

--- a/pages/deployment/embedding.mdx
+++ b/pages/deployment/embedding.mdx
@@ -17,7 +17,7 @@ Add a `<script>` tag to your page to load the Embeddable custom element:
 ```html
 <script 
   type="module"
-  src="https://api.<region>.embeddable.com/js/v1/">
+  src="https://embed.embeddable.com/js/v1/?region=<region>">
 </script>
 ```
 
@@ -51,7 +51,7 @@ The quickest way to test embedding is to use our test script [here](/getting-sta
   <head>
     <script 
       type="module"
-      src="https://api.<region>.embeddable.com/js/v1/">
+      src="https://embed.embeddable.com/js/v1/?region=<region>">
     </script>
   </head>
   <body>
@@ -92,7 +92,7 @@ export default function DashboardPage() {
     <>
       <script
         type="module"
-        src="https://api.<region>.embeddable.com/js/v1/"
+        src="https://embed.embeddable.com/js/v1/?region=<region>"
       />
       <em-beddable
         token="eyJhbGciOiJI..."
@@ -135,7 +135,7 @@ Make sure you’ve loaded the script in your `index.html` (or another entry poin
 ```html
 <script 
   type="module"
-  src="https://api.<region>.embeddable.com/js/v1/">
+  src="https://embed.embeddable.com/js/v1/?region=<region>">
 </script>
 ```
 


### PR DESCRIPTION
In scope of [PROD-174](https://trevorio.atlassian.net/browse/PROD-174) we added support for `https://embed.embeddable.com/js/v1/?region=<region>` endpoint but it hasn't been used in the examples.

This PR updates examples to use `https://embed.embeddable.com/js/v1/?region=<region>` 

[PROD-174]: https://trevorio.atlassian.net/browse/PROD-174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ