### PR TITLE
Add all components to the starter components page

### DIFF
--- a/pages/dashboards/starter-components.mdx
+++ b/pages/dashboards/starter-components.mdx
@@ -11,7 +11,7 @@ You can easily **theme** or **customize** them to fit your brand and data needs.
 
 We're going to expand this page with more examples and images, but for now here's a list of the components available in the starter library, and what they do:
 
-## Components in the Starter Library
+## Components
 
 ### Charts: Essentials
 


### PR DESCRIPTION
Doing this so that we can then reference the page in the Dimensions / Measures as Variables PR (#94) without just leading users to an empty page.