### PR TITLE
remove 'latest'

### DIFF
--- a/pages/deployment/tokens-api.mdx
+++ b/pages/deployment/tokens-api.mdx
@@ -51,7 +51,6 @@ Learn more about `region` [here](/deployment/deployment-regions).
 
 - **`embeddableId`** is the id of the Embeddable dashboard that you want to load.  Click 'save version' or 'publish' on your Embeddable dashboard to get the id.
 - **`savedVersion`** this is the saved version of the Embeddable dashboard that you want to load.  Available options include: 
-  - 'latest' - the most recently saved version.
   - 'production' (default) - the saved version published with the 'Production' tag.  This will be used by default if `savedVersion` is omitted.
   - 'staging' - the saved version published with the 'Staging' tag
   - 'development' - the saved version published with the 'Development' tag


### PR DESCRIPTION
We're making 'production' the default value, and removing 'latest' as an option.  Updating docs to reflect this.