### PR TITLE
Remove Cookie Warning in Dev

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -6,17 +6,19 @@ class MyDocument extends Document {
     return (
       <Html>
         <Head>
-          <script
-            dangerouslySetInnerHTML={{
-              __html: `
+          {process.env.NODE_ENV !== "development" && (
+            <script
+              dangerouslySetInnerHTML={{
+                __html: `
                 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
                 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
                 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
                 })(window,document,'script','dataLayer','GTM-5JVQ8XW');
-              `
-            }}
-          />
+              `,
+              }}
+            />
+          )}
         </Head>
         <body>
           <noscript>


### PR DESCRIPTION
Gets rid of the cookie warning when running the handbook locally, but keeps it in other environments.