### PR TITLE
Patch notes for v1.1.7

### DIFF
--- a/pages/patch-notes.mdx
+++ b/pages/patch-notes.mdx
@@ -6,6 +6,10 @@ title: Patch Notes - Vanilla Components v1
 
 Version 1 of Vanilla Components introduced components as an NPM package, and is the new standard for Embeddable development that this documentation references. This page contains patch notes for each NPM release of Vanilla Components, including bug fixes, new features, and breaking changes (if any).
 
+## Version 1.1.7 - Bug Fixes
+  - Updated Bar Chart "limit" input to properly reflect the existing default
+  - Fixed a bug that was causing the stacked area chart to render a blank canvas in certain circumstances
+
 ## Version 1.1.6 - Internal Fix
 
   - Fixed an internal issue relating to publishing to NPM.
@@ -22,7 +26,6 @@ Version 1 of Vanilla Components introduced components as an NPM package, and is 
   - Added a new component: Heat Grid! It's a Github-style heatmap grid that can be used to visualize data over time.
 
 <ImageGrid width='90%' images={["/img/heat-grid.png"]}/>
-
 
 ## Version 1.1.3 - Small Fixes
   - Fixed "default sort direction" on Table component not always being applied


### PR DESCRIPTION
  - Updated Bar Chart "limit" input to properly reflect the existing default
  - Fixed a bug that was causing the stacked area chart to render a blank canvas in certain circumstances