### PR TITLE
Update DuckDb credentials

### DIFF
--- a/pages/data/credentials.mdx
+++ b/pages/data/credentials.mdx
@@ -186,16 +186,21 @@ credentials: {
 }
 ```
 
-### DuckDB
+### MotherDuck/DuckDB
 [Cube docs](https://cube.dev/docs/product/configuration/data-sources/duckdb)
 ```javascript
 type: 'duckdb',
 credentials: {
+  // Option 1: MotherDuck Cloud - Run DuckDB fully in the cloud using only your MotherDuck token.
   motherDuckToken: '...',
+  
+  // Option 2: Query Parquet or CSV files directly from object storage (S3, GCS, etc.)
   // dataSource: '...',
   // initSql: '...',
   // schema: '...',
   // duckdbS3UseCredentialChain: '...',
+  
+  // Option 3: Connect to a DuckDB file on your local machine.
   // databasePath: '...'
 }
 ```


### PR DESCRIPTION
Clarified docs to show support for both MotherDuck and DuckDB

Separated credential options for MotherDuck, cloud storage (S3/GCS), and local DuckDB.

Associated Ticket: https://trevorio.atlassian.net/jira/software/projects/CS/boards/13?selectedIssue=CS-141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Renamed the DuckDB section to “MotherDuck/DuckDB” and updated the external documentation link.
  * Expanded credential examples to illustrate three usage patterns: MotherDuck Cloud, S3/warehouse configuration, and local file usage.
  * Added clear, commented guidance for each option to help users choose and configure the appropriate setup.
  * Included an example token-based configuration for cloud usage.
  * No functional changes; updates are purely instructional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->