### PR TITLE
Add Windows troubleshooting for module errors

### DIFF
--- a/pages/getting-started/download-repo.mdx
+++ b/pages/getting-started/download-repo.mdx
@@ -42,6 +42,17 @@ npm run embeddable:build
 ```
 </Steps>
 
+On Windows, you may encounter an like `Cannot find module './swc.win32-x64-msvc.node'` at this point.
+
+Make sure you have Microsoft Visual C++ Redistributable installed. https://docs.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist
+
+Following this, delete `node_modules` and `package-lock.json`. Finally, install your `node_modules` again:
+
+```bash
+npm i
+```
+
+
 ## Next steps
 
 You're now ready to set up your workspace and push your first code bundle. 


### PR DESCRIPTION
# Note for Windows users missing Microsoft Visual C++ Redistributable

When following the quick start guide, I got this error after running `npm run embeddable:build`:

`Cannot find module './swc.win32-x64-msvc.node'`

Installing the Microsoft Visual C++ Redistributable resolves the issue. Added a note about this to the guide.