### PR TITLE
Add Remarkable Pro v0.2.0 to changelog

### DIFF
--- a/pages/component-libraries/remarkable-pro/changelog.json
+++ b/pages/component-libraries/remarkable-pro/changelog.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "v0.2.0",
+    "date": "2026-04-09",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.0",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.2.0",
+    "notes": [
+      "Added timezone support via `clientContext`, enabling chart components and date range controls to display time-based data in the correct business timezone."
+    ]
+  },
+  {
     "version": "v0.1.32",
     "date": "2026-04-02",
     "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.1.32",


### PR DESCRIPTION
## Summary

Adds the **v0.2.0** release of Remarkable Pro to the handbook changelog.

### Release: v0.2.0 (2026-04-09)

- **Minor change:** Added timezone support via `clientContext`, enabling chart components and date range controls to display time-based data in the correct business timezone.

### Source

- GitHub release: https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.0
- NPM: https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.2.0
- Release PR: embeddable-hq/remarkable-pro#157 ("Version Packages", merged 2026-04-09)
- Feature PR: embeddable-hq/remarkable-pro#154 ("RUI-85: timezone support", merged 2026-04-09)