### PR TITLE
Update security-filters.mdx

### DIFF
--- a/pages/data-modeling/row-level-security/security-filters.mdx
+++ b/pages/data-modeling/row-level-security/security-filters.mdx
@@ -44,20 +44,15 @@ How the field is compared to the values.
 | `contains` | Case-insensitive substring match. |
 | `notContains` | Inverse of contains. |
 | `startsWith` | Prefix match. |
-| `notStartsWith` | Inverse of startsWith. |
 | `endsWith` | Suffix match. |
-| `notEndsWith` | Inverse of endsWith. |
 | `gt` | Greater than a numeric value. |
 | `gte` | Greater than or equal to a numeric value. |
 | `lt` | Less than a numeric value. |
 | `lte` | Less than or equal to a numeric value. |
 | `inDateRange` | Time member is within the given range. |
 | `notInDateRange` | Excludes rows within the given range. |
-| `onTheDate` | Member is on the exact date provided. |
 | `beforeDate` | Strictly before the given timestamp. |
-| `beforeOrOnDate` | Before or on the given timestamp. |
 | `afterDate` | Strictly after the given timestamp. |
-| `afterOrOnDate` | After or on the given timestamp. |
 | `set` | Member is **NOT NULL** (omit `values`). |
 | `notSet` | Member is **NULL** (omit `values`). |
 


### PR DESCRIPTION
Description:

The security filter operators [documentation](https://docs.embeddable.com/data-modeling/row-level-security/security-filters#filter-fields) listed 5 operators that are not supported by the Embeddable backend ([CubeFilterOperator enum)](https://github.com/embeddable-hq/embeddable-backend/blob/800cdd726e91d7974113f340fc3e9ae3c31fb8a4/src/main/kotlin/com/embeddable/backend/external/cube/common/dto/CubeFilterOperator.kt#L22):

  - notStartsWith
  - notEndsWith
  - onTheDate
  - beforeOrOnDate
  - afterOrOnDate

This was raised by a customer and then this was confirmed unsupported by attempting to push a security context using each operator — the backend rejected the bundle with a BUILDER-052 error, listing only the valid enum values. None of the 5 operators appear in the [CubeFilterOperator enum](https://github.com/embeddable-hq/embeddable-backend/blob/800cdd726e91d7974113f340fc3e9ae3c31fb8a4/src/main/kotlin/com/embeddable/backend/external/cube/common/dto/CubeFilterOperator.kt#L22).

Changes:
- Remove the 5 unsupported operators from the security filters operator table in the docs.