### PR TITLE
chore: add remarkable-pro v0.2.1 to changelog

### DIFF
--- a/pages/component-libraries/remarkable-pro/changelog.json
+++ b/pages/component-libraries/remarkable-pro/changelog.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "v0.2.1",
+    "date": "2026-04-13",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.1",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.2.1",
+    "notes": [
+      "Fixed markdown content scrolling behavior in the `ScrollableTable` component."
+    ]
+  },
+  {
     "version": "v0.2.0",
     "date": "2026-04-09",
     "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.0",


### PR DESCRIPTION
## Remarkable Pro v0.2.1 — 2026-04-13

**Release:** [v0.2.1](https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.1) | **NPM:** [@embeddable.com/remarkable-pro@0.2.1](https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.2.1)

### Changes
- Fixed markdown content scrolling behavior in the `ScrollableTable` component. (embeddable-hq/remarkable-pro#158)

---
_Auto-generated by the daily changelog sync at 19:00 CET._