### PR TITLE
chore: add Remarkable Pro v0.2.2 to changelog

### DIFF
--- a/pages/component-libraries/remarkable-pro/changelog.json
+++ b/pages/component-libraries/remarkable-pro/changelog.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "v0.2.2",
+    "date": "2026-04-15",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.2",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.2.2",
+    "notes": [
+      "The `FilterBuilder` component now supports configurable default filter values via a `defaultFilters` prop, allowing filters to be pre-populated on initial load."
+    ]
+  },
+  {
     "version": "v0.2.1",
     "date": "2026-04-13",
     "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.1",


### PR DESCRIPTION
## Summary

Adds the `v0.2.2` entry to the Remarkable Pro changelog.

**Release**: [v0.2.2](https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.2) — published 2026-04-15

### Changes in this release
- The `FilterBuilder` component now supports configurable default filter values via a `defaultFilters` prop, allowing filters to be pre-populated on initial load. ([PR #160](https://github.com/embeddable-hq/remarkable-pro/pull/160))

> Note: PR #162 (improved test coverage for FilterBuilder) was merged after the v0.2.2 release tag and will be included in the next release.