### PR TITLE
chore: Remarkable Pro changelog for v0.2.3 and v0.2.4 (2026-04-17)

### DIFF
--- a/pages/component-libraries/remarkable-pro/changelog.json
+++ b/pages/component-libraries/remarkable-pro/changelog.json
@@ -1,5 +1,23 @@
 [
   {
+    "version": "v0.2.4",
+    "date": "2026-04-17",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.4",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.2.4",
+    "notes": [
+      "Added new `LineChartWithKpiTabsPro` component, combining tabbed KPI metrics with a line chart visualisation."
+    ]
+  },
+  {
+    "version": "v0.2.3",
+    "date": "2026-04-17",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.3",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.2.3",
+    "notes": [
+      "Fixed a bug in `ScrollableTable` where a dimension column would not display when the first data row was missing that key."
+    ]
+  },
+  {
     "version": "v0.2.2",
     "date": "2026-04-15",
     "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.2",


### PR DESCRIPTION
## Remarkable Pro releases — 2026-04-17

Two releases shipped today:

### v0.2.4
- **New component:** `LineChartWithKpiTabsPro` — combines tabbed KPI metrics with a line chart visualisation (PR [#168](https://github.com/embeddable-hq/remarkable-pro/pull/168))
- [GitHub release](https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.4) · [npm](https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.2.4)

### v0.2.3
- **Bug fix:** `ScrollableTable` now correctly displays a dimension column even when the first data row is missing that key (PR [#166](https://github.com/embeddable-hq/remarkable-pro/pull/166))
- [GitHub release](https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.3) · [npm](https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.2.3)