### PR TITLE
chore: add Remarkable Pro v0.2.5 to changelog

### DIFF
--- a/pages/component-libraries/remarkable-pro/changelog.json
+++ b/pages/component-libraries/remarkable-pro/changelog.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "v0.2.5",
+    "date": "2026-04-24",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.5",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.2.5",
+    "notes": [
+      "Added `ScatterChartPro` component for X/Y coordinate visualisation with optional grouping, configurable point colours, axis labels and ranges, interactive point-click events, and theme-level customisation."
+    ]
+  },
+  {
     "version": "v0.2.4",
     "date": "2026-04-17",
     "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.4",


### PR DESCRIPTION
## Summary

Adds the **v0.2.5** entry to the Remarkable Pro changelog.

### v0.2.5 (2026-04-24)
- Added `ScatterChartPro` component for X/Y coordinate visualisation with optional grouping, configurable point colours, axis labels and ranges, interactive point-click events, and theme-level customisation.

**Source:** [GitHub release](https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.5) · [NPM](https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.2.5) · [PR #156](https://github.com/embeddable-hq/remarkable-pro/pull/156)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vb7nFjZjuJJAtYa4HjPaWu)_