### PR TITLE
Add Remarkable Pro v0.2.5 and v0.2.6 changelog entries

### DIFF
--- a/pages/component-libraries/remarkable-pro/changelog.json
+++ b/pages/component-libraries/remarkable-pro/changelog.json
@@ -1,5 +1,23 @@
 [
   {
+    "version": "v0.2.6",
+    "date": "2026-04-27",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.6",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.2.6",
+    "notes": [
+      "Table charts (`TableChartPaginated` and `ScrollableTable`) now expose dedicated `sortColumn` and `sortDirection` input fields for configuring default sort behaviour. The dataset-level sort button has been hidden to prevent conflicts with runtime interactive sorting."
+    ]
+  },
+  {
+    "version": "v0.2.5",
+    "date": "2026-04-24",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.5",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.2.5",
+    "notes": [
+      "Added `ScatterPlotPro` chart component for X/Y coordinate visualisation with optional grouping, configurable point colours, axis labels and ranges, and point-click event support."
+    ]
+  },
+  {
     "version": "v0.2.4",
     "date": "2026-04-17",
     "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.4",


### PR DESCRIPTION
## Summary

Adds two missing changelog entries for Remarkable Pro releases published since the last handbook update (v0.2.4).

### v0.2.5 (2026-04-24)
- Added `ScatterPlotPro` chart component for X/Y coordinate visualisation with optional grouping, configurable point colours, axis labels and ranges, and point-click event support.
- Source: [remarkable-pro PR #156](https://github.com/embeddable-hq/remarkable-pro/pull/156) · [GitHub release](https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.5) · [npm](https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.2.5)

### v0.2.6 (2026-04-27)
- Table charts (`TableChartPaginated` and `ScrollableTable`) now expose dedicated `sortColumn` and `sortDirection` input fields for configuring default sort behaviour. The dataset-level sort button has been hidden to prevent conflicts with runtime interactive sorting.
- Source: [remarkable-pro PR #170](https://github.com/embeddable-hq/remarkable-pro/pull/170) · [GitHub release](https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.6) · [npm](https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.2.6)

> Note: PR #171 (formatting improvements — tooltips/exports) was merged to remarkable-pro today at 10:16 UTC, after the v0.2.6 release PR closed at 08:59 UTC. It is not yet released and is not included here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GNPxczyEcYyeXDuB58Hxc1)_