### PR TITLE
chore: Remarkable Pro changelog — v0.2.7 and v0.2.8 (2026-04-28)

### DIFF
--- a/pages/component-libraries/remarkable-pro/changelog.json
+++ b/pages/component-libraries/remarkable-pro/changelog.json
@@ -1,5 +1,23 @@
 [
   {
+    "version": "v0.2.8",
+    "date": "2026-04-28",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.8",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.2.8",
+    "notes": [
+      "All interactive chart types (bar, line, pie, scatter, and table) now emit a companion `*DimensionTimeRange` event property alongside the existing `*DimensionValue` property. For time-type dimensions, this provides a `TimeRange` covering the full granularity bucket of the clicked data point (e.g. clicking a monthly bar returns the full month range), making it straightforward to wire click events directly to date-range filters."
+    ]
+  },
+  {
+    "version": "v0.2.7",
+    "date": "2026-04-28",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.7",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.2.7",
+    "notes": [
+      "Tooltips no longer apply label truncation — the `maxCharacters` setting is now ignored in tooltips so the full label is always shown. CSV and Excel exports now write raw unformatted values instead of abbreviated ones (e.g. `90000000` instead of `90M`), making them suitable for downstream calculations."
+    ]
+  },
+  {
     "version": "v0.2.6",
     "date": "2026-04-27",
     "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.6",


### PR DESCRIPTION
Adds changelog entries for two Remarkable Pro releases shipped today.

## v0.2.8
- **PR #178** (Version Packages) merged at 13:06 UTC
- **PR #177 / #172** (RUI-258: drilldown timeRange events) merged at 12:49–12:53 UTC
- All interactive chart types now emit a companion `*DimensionTimeRange` event property so click events on time-dimension data points can be wired directly to date-range filters.

## v0.2.7
- **PR #175** (Version Packages) merged at 09:45 UTC
- **PR #171** (R UI 259 formatting improvements) merged at 10:16 UTC
- Tooltips no longer truncate labels. CSV/Excel exports now write raw unformatted values.

GitHub releases: [v0.2.7](https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.7) · [v0.2.8](https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.8)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERRoHyVTTi5tH5Tkte8GkF)_