### PR TITLE
Add Remarkable Pro v0.2.9 to changelog

### DIFF
--- a/pages/component-libraries/remarkable-pro/changelog.json
+++ b/pages/component-libraries/remarkable-pro/changelog.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "v0.2.9",
+    "date": "2026-04-30",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.9",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.2.9",
+    "notes": [
+      "Added `ComparisonLineChartWithKpiTabsPro` component — a new chart that enables side-by-side comparison of data across two date periods, with interactive KPI tabs displaying metrics and trend indicators."
+    ]
+  },
+  {
     "version": "v0.2.8",
     "date": "2026-04-28",
     "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.8",


### PR DESCRIPTION
## Summary

Adds the **v0.2.9** release to the Remarkable Pro changelog.

### v0.2.9 (2026-04-30)
- Added `ComparisonLineChartWithKpiTabsPro` component — a new chart that enables side-by-side comparison of data across two date periods, with interactive KPI tabs displaying metrics and trend indicators.

**Source:** [GitHub release](https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.9) | [NPM](https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.2.9) | [PR #176](https://github.com/embeddable-hq/remarkable-pro/pull/176)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjTX5KtW7qQNzHSbkRpw4W)_