### PR TITLE
chore: add remarkable-pro v0.2.10 to changelog

### DIFF
--- a/pages/component-libraries/remarkable-pro/changelog.json
+++ b/pages/component-libraries/remarkable-pro/changelog.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "v0.2.10",
+    "date": "2026-05-07",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.10",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.2.10",
+    "notes": [
+      "Added `BubbleChartPro` component for visualising three-dimensional data as X/Y scatter points scaled by a configurable size measure. Supports adjustable minimum and maximum bubble radius bounds, optional point labels, theme customisation, and click events that include the bubble's size value."
+    ]
+  },
+  {
     "version": "v0.2.9",
     "date": "2026-04-30",
     "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.9",


### PR DESCRIPTION
Adds the v0.2.10 release entry to the Remarkable Pro changelog.\n\n## Release: v0.2.10 (2026-05-07)\n\n- **New component:** `BubbleChartPro` — visualises three-dimensional data as X/Y scatter points scaled by a configurable size measure, with adjustable min/max bubble radius bounds, optional point labels, theme customisation, and click events that include the bubble's size value.\n\n### Source\n- GitHub release PR: https://github.com/embeddable-hq/remarkable-pro/pull/183\n- Feature PR: https://github.com/embeddable-hq/remarkable-pro/pull/180\n- GitHub release: https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.2.10\n- npm: https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.2.10

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4XWKpvP8hEyL8PzBRZFso)_