### PR TITLE
Fix incorrect IP address for US SSH

### DIFF
--- a/pages/deployment/deployment-regions.mdx
+++ b/pages/deployment/deployment-regions.mdx
@@ -72,7 +72,7 @@ For direct database connections:
 
 For connections via SSH:
 
- - For US use `35.171.35.74` **and** `35.171.35.74`
+ - For US use `54.149.56.113` **and** `35.171.35.74`
  - For EU use `3.77.50.38` **and** `52.18.76.185`
 
 For safety, whether you use direct or SSH connections, we recommend whitelisting all four IPs for your region.


### PR DESCRIPTION
We had a duplicate IP address instead of two separate ones.