### PR TITLE
Add Remarkable Pro v0.3.1 changelog entry

### DIFF
--- a/pages/component-libraries/remarkable-pro/changelog.json
+++ b/pages/component-libraries/remarkable-pro/changelog.json
@@ -1,5 +1,16 @@
 [
   {
+    "version": "v0.3.1",
+    "date": "2026-05-26",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.1",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.1",
+    "notes": [
+      "Exported `FilterBuilderPro` component — it is now directly importable from the package with full TypeScript type support.",
+      "Chart components now ship with explicitly defined default dimensions for consistent out-of-the-box sizing; comparison period input descriptions have been updated for improved dashboard-as-code compatibility.",
+      "Sorted the component index file."
+    ]
+  },
+  {
     "version": "v0.3.0",
     "date": "2026-05-18",
     "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.0",


### PR DESCRIPTION
## Summary

Adds the changelog entry for Remarkable Pro **v0.3.1**, released 2026-05-26.

### Changes in v0.3.1

- **Export `FilterBuilderPro`** (PR [#197](https://github.com/embeddable-hq/remarkable-pro/pull/197)) — `FilterBuilderPro` is now directly importable from the package with full TypeScript type support.
- **Component default dimensions** (PR [#196](https://github.com/embeddable-hq/remarkable-pro/pull/196)) — Chart components now ship with explicitly defined default dimensions for consistent out-of-the-box sizing; comparison period input descriptions updated for dashboard-as-code compatibility.
- **Sort index file** (PR [#199](https://github.com/embeddable-hq/remarkable-pro/pull/199)) — Component index file sorted for consistency.

Release PR: [embeddable-hq/remarkable-pro#200](https://github.com/embeddable-hq/remarkable-pro/pull/200)
GitHub release: https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.1
NPM: https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.1

---
_Generated by [Claude Code](https://claude.ai/code/session_01BivEzhkmDtQKGFxnnv72cq)_