### PR TITLE
chore: add Remarkable Pro v0.3.3 to changelog

### DIFF
--- a/pages/component-libraries/remarkable-pro/changelog.json
+++ b/pages/component-libraries/remarkable-pro/changelog.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "v0.3.3",
+    "date": "2026-05-29",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.3",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.3",
+    "notes": [
+      "Fixed focus behaviour in `FilterBuilderPro` — input focus and value auto-selection now activate only when a new filter is being created, preventing unwanted focus when editing existing filter values."
+    ]
+  },
+  {
     "version": "v0.3.2",
     "date": "2026-05-28",
     "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.2",


### PR DESCRIPTION
## Remarkable Pro v0.3.3 — 2026-05-29

Adds the v0.3.3 release entry to the changelog.

### What changed in v0.3.3

- **Fixed focus behaviour in `FilterBuilderPro`** — input focus and value auto-selection now activate only when a new filter is being created, preventing unwanted focus when editing existing filter values.

### Source

- GitHub release: https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.3
- Feature PR: https://github.com/embeddable-hq/remarkable-pro/pull/204 (RUI-281: filter builder improvements)
- Release PR: https://github.com/embeddable-hq/remarkable-pro/pull/205 (Version Packages — merged 2026-05-29)
- npm: https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.3

---
_Generated by [Claude Code](https://claude.ai/code/session_018KQW6h8EqBvkS6Baufnc88)_