### PR TITLE
Add Remarkable Pro v0.3.4 to changelog

### DIFF
--- a/pages/component-libraries/remarkable-pro/changelog.json
+++ b/pages/component-libraries/remarkable-pro/changelog.json
@@ -1,5 +1,18 @@
 [
   {
+    "version": "v0.3.4",
+    "date": "2026-06-09",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.4",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.4",
+    "notes": [
+      "Fixed percentage datalabels and tooltips in pie/donut charts, bar charts, and bar+line combo charts now correctly respecting the per-measure `decimalPlaces` subinput — previously the decimal precision was hardcoded to 2 decimal places regardless of configuration.",
+      "The `onLineClicked` event on `LineChartComparisonDefaultPro` now includes a `measureValue` property, providing the numeric value of the clicked data point alongside the existing `dimensionValue` and `dimensionTimeRange`.",
+      "Added `onCellClicked` event to `HeatMapPro`, emitting `rowDimensionValue`, `rowDimensionTimeRange`, `columnDimensionValue`, and `columnDimensionTimeRange` on each cell click — enabling independent row and column filter wiring from a single click interaction.",
+      "Fixed `MeasureMultiSelectFieldPro` and `DimensionOrMeasureMultiSelectFieldPro` displaying model-qualified measure titles (e.g. \"Products # of orders\") when variable defaults were set — titles are now normalised to their short display form (e.g. \"# of orders\") on mount.",
+      "Upgraded the Remarkable UI library."
+    ]
+  },
+  {
     "version": "v0.3.3",
     "date": "2026-05-29",
     "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.3",


### PR DESCRIPTION
Adds the v0.3.4 release entry to the Remarkable Pro changelog.

## Changes in v0.3.4 (2026-06-09)

**GitHub release:** https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.4  
**NPM:** https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.4

### What's documented

- **Percentage decimal places fix** (PR #207) — `showValueAsPercentage` now correctly respects the per-measure `decimalPlaces` subinput across pie/donut charts, bar charts, and bar+line combo charts. Previously hardcoded to 2 decimal places.
- **`measureValue` in comparison line chart click handler** (PR #211) — `onLineClicked` on `LineChartComparisonDefaultPro` now emits `measureValue` alongside `dimensionValue` and `dimensionTimeRange`.
- **`HeatMapPro` cell click interactions** (PR #212) — New `onCellClicked` event emits `rowDimensionValue`, `rowDimensionTimeRange`, `columnDimensionValue`, and `columnDimensionTimeRange`, enabling independent row/column filter wiring from a single click.
- **Multi-select measure title normalisation** (PR #210) — Fixed model-qualified titles (e.g. "Products # of orders") in `MeasureMultiSelectFieldPro` and `DimensionOrMeasureMultiSelectFieldPro` when variable defaults are set; titles now normalise to short display form on mount.
- **Upgraded Remarkable UI library** (PR #213).

> Note: PRs #210 and #212 were merged just before the Version Packages PR and are included in the released package but have no formal changeset entry — their changes have been documented here based on the PR descriptions.

---
_Generated by [Claude Code](https://claude.ai/code/session_013Q256XDJDun6cYidPeLHtx)_