### PR TITLE
Add Remarkable Pro v0.3.5 to changelog

### DIFF
--- a/pages/component-libraries/remarkable-pro/changelog.json
+++ b/pages/component-libraries/remarkable-pro/changelog.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "v0.3.5",
+    "date": "2026-06-15",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.5",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.5",
+    "notes": [
+      "Added cascading filter support to `FilterBuilderPro` via a new 'Apply dynamic filters' boolean input (Component Settings). When enabled, each filter clause's value dropdown is automatically narrowed by all other active clauses — for example, selecting a Country first will filter the available City options accordingly. Each clause's own selections are excluded from its own filtering, so multiple values can still be added to a single clause without interference."
+    ]
+  },
+  {
     "version": "v0.3.4",
     "date": "2026-06-09",
     "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.4",


### PR DESCRIPTION
## Summary

Adds the [v0.3.5](https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.5) release entry to the Remarkable Pro changelog.

**Released:** 2026-06-15

**Changes:**
- Added cascading filter support to `FilterBuilderPro` via a new "Apply dynamic filters" boolean input. When enabled, each filter clause's value dropdown is automatically narrowed by all other active clauses (e.g. selecting a Country first filters the available City options). Each clause's own selections are excluded from its own filtering, so multiple values can still be added to a single clause without interference.

**Source PR:** [#214 - [RUI-282] Filter builder updates](https://github.com/embeddable-hq/remarkable-pro/pull/214)
**NPM:** https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.5

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7kM1nyoNmZJZonJXuPtmB)_

[RUI-282]: https://trevorio.atlassian.net/browse/RUI-282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ