### PR TITLE
Add Remarkable Pro v0.3.5 and v0.3.6 to changelog

### DIFF
--- a/pages/component-libraries/remarkable-pro/changelog.json
+++ b/pages/component-libraries/remarkable-pro/changelog.json
@@ -1,5 +1,24 @@
 [
   {
+    "version": "v0.3.6",
+    "date": "2026-06-17",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.6",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.6",
+    "notes": [
+      "Fixed tooltip positioning across chart components by updating the Remarkable UI library to 3.0.19.",
+      "Fixed pie and donut chart legend labels ignoring the active theme's colour setting — labels now correctly apply the `--em-chart-category-color` CSS variable instead of always rendering in black."
+    ]
+  },
+  {
+    "version": "v0.3.5",
+    "date": "2026-06-15",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.5",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.5",
+    "notes": [
+      "Extended `FilterBuilderPro` with cascading filter support via a new \"Apply dynamic filters\" boolean component setting. When enabled, each clause's value dropdown is automatically narrowed by all other active clauses — for example, selecting a Country first filters the available City options. Each clause's own selections are excluded from its own filtering, so multiple values can still be added to a single clause."
+    ]
+  },
+  {
     "version": "v0.3.4",
     "date": "2026-06-09",
     "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.4",


### PR DESCRIPTION
## Summary

Adds changelog entries for two new Remarkable Pro releases.

---

### v0.3.6 — 2026-06-17

**GitHub:** https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.6
**NPM:** https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.6

- Fixed tooltip positioning across chart components by updating the Remarkable UI library to 3.0.19. (PR [#216](https://github.com/embeddable-hq/remarkable-pro/pull/216))
- Fixed pie and donut chart legend labels ignoring the active theme's colour setting — labels now correctly apply the `--em-chart-category-color` CSS variable instead of always rendering in black. (PR [#217](https://github.com/embeddable-hq/remarkable-pro/pull/217))

---

### v0.3.5 — 2026-06-15

**GitHub:** https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.5
**NPM:** https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.5

- Extended `FilterBuilderPro` with cascading filter support via a new "Apply dynamic filters" boolean component setting. When enabled, each clause's value dropdown is automatically narrowed by all other active clauses — for example, selecting a Country first filters the available City options. Each clause's own selections are excluded from its own filtering, so multiple values can still be added to a single clause. (PR [#214](https://github.com/embeddable-hq/remarkable-pro/pull/214))

---

_Supersedes #300 (v0.3.5 only)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01NoRV4y5uATFgFGz74BP8oP)_