### PR TITLE
small padding issue fixed

### DIFF
--- a/components/LinkCard.tsx
+++ b/components/LinkCard.tsx
@@ -26,7 +26,7 @@ const LinkCard: React.FC<LinkCardProps> = ({ title, href, icon, children, margin
             {title}
             <span>&#x2192;</span>
           </h3>
-          {children && <p className="text-sm opacity-80">{children}</p>}
+          {children && <p className="text-sm opacity-80 nx-px-4 nx-pb-4">{children}</p>}
         </div>
       </div>
     </Link>


### PR DESCRIPTION
This fixes a small visual issue with the linkcards, where the description beneath the title had no padding