### PR TITLE
Add Remarkable Pro v0.3.7 to changelog

### DIFF
--- a/pages/component-libraries/remarkable-pro/changelog.json
+++ b/pages/component-libraries/remarkable-pro/changelog.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "v0.3.7",
+    "date": "2026-06-18",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.7",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.7",
+    "notes": [
+      "Chart components now expose an `exportOptions` setting in the component builder, allowing builders to control which export formats (CSV, XLSX, PNG) are available in each chart's export menu — or disable exports entirely on a per-component basis."
+    ]
+  },
+  {
     "version": "v0.3.6",
     "date": "2026-06-17",
     "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.6",


### PR DESCRIPTION
## Summary

Adds the v0.3.7 release entry to the Remarkable Pro changelog.

**v0.3.7** (2026-06-18)
- Chart components now expose an `exportOptions` setting in the component builder, allowing builders to control which export formats (CSV, XLSX, PNG) are available in each chart's export menu — or disable exports entirely on a per-component basis.
  - Source: [PR #208](https://github.com/embeddable-hq/remarkable-pro/pull/208) — [RUI-280]: Add export options to component settings in builder
  - GitHub release: https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.7
  - NPM: https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.7

_Auto-generated by the daily changelog routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_011HwCDGN43k7HmT21FJffDj)_

[RUI-280]: https://trevorio.atlassian.net/browse/RUI-280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ