### PR TITLE
Add Remarkable Pro v0.3.8 to changelog

### DIFF
--- a/pages/component-libraries/remarkable-pro/changelog.json
+++ b/pages/component-libraries/remarkable-pro/changelog.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "v0.3.8",
+    "date": "2026-06-19",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.8",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.8",
+    "notes": [
+      "Upgraded the Remarkable UI library to 3.0.20, adding support for custom canvas overlay customisation — chart components can now render custom content overlaid directly on top of the chart canvas."
+    ]
+  },
+  {
     "version": "v0.3.7",
     "date": "2026-06-18",
     "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.7",


### PR DESCRIPTION
## Summary

Adds the **v0.3.8** release to the Remarkable Pro changelog.

**Release date:** 2026-06-19  
**GitHub release:** https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.8  
**NPM:** https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.8

### What's new in v0.3.8

- Upgraded the Remarkable UI library to 3.0.20, adding support for custom canvas overlay customisation — chart components can now render custom content overlaid directly on top of the chart canvas. (via [PR #221](https://github.com/embeddable-hq/remarkable-pro/pull/221))

---
_Generated automatically by the daily changelog routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01KfUJtJ4P7wHQEXDLWvdTcp)_