### PR TITLE
Add Remarkable Pro v0.3.8 and v0.3.9 to changelog

### DIFF
--- a/pages/component-libraries/remarkable-pro/changelog.json
+++ b/pages/component-libraries/remarkable-pro/changelog.json
@@ -1,5 +1,23 @@
 [
   {
+    "version": "v0.3.9",
+    "date": "2026-06-22",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.9",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.9",
+    "notes": [
+      "`FilterBuilderPro` now supports an AND/OR operator toggle — a button appears between each pair of adjacent filter clauses allowing the top-level logic to switch between AND (all clauses must match) and OR (any clause may match). The selected operator defaults to AND, is persisted in `FilterBuilderState`, and is included in the filter output."
+    ]
+  },
+  {
+    "version": "v0.3.8",
+    "date": "2026-06-19",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.8",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.8",
+    "notes": [
+      "Added support for custom canvas overlay customisation — chart components can now render custom content directly on top of the chart canvas, enabled by an upgrade to Remarkable UI 3.0.20."
+    ]
+  },
+  {
     "version": "v0.3.7",
     "date": "2026-06-18",
     "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.7",


### PR DESCRIPTION
## Summary

Adds two new releases to the Remarkable Pro changelog.

---

### v0.3.9 — 2026-06-22
**GitHub release:** https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.9
**NPM:** https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.9

- `FilterBuilderPro` now supports an AND/OR operator toggle — a button appears between each pair of adjacent filter clauses allowing the top-level logic to switch between AND (all clauses must match) and OR (any clause may match). Defaults to AND, persisted in `FilterBuilderState`, and included in the filter output. (via [PR #220](https://github.com/embeddable-hq/remarkable-pro/pull/220))

---

### v0.3.8 — 2026-06-19
**GitHub release:** https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.8
**NPM:** https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.8

- Added support for custom canvas overlay customisation — chart components can now render custom content directly on top of the chart canvas, enabled by an upgrade to Remarkable UI 3.0.20. (via [PR #221](https://github.com/embeddable-hq/remarkable-pro/pull/221))

---

_Supersedes [#307](https://github.com/embeddable-hq/handbook/pull/307), which only covered v0.3.8._

_Generated automatically by the daily changelog routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJPeEAPNqF7BP8LFZG1LzL)_