### PR TITLE
Add Remarkable Pro v0.3.11, v0.3.12, and v0.3.13 to changelog

### DIFF
--- a/pages/component-libraries/remarkable-pro/changelog.json
+++ b/pages/component-libraries/remarkable-pro/changelog.json
@@ -1,5 +1,32 @@
 [
   {
+    "version": "v0.3.13",
+    "date": "2026-07-01",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.13",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.13",
+    "notes": [
+      "Updated the Remarkable UI dependency to version 3.0.21, which extends the date-picker to support date selection up to five years in the future."
+    ]
+  },
+  {
+    "version": "v0.3.12",
+    "date": "2026-07-01",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.12",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.12",
+    "notes": [
+      "Fixed the KPI chart not respecting the viewer's timezone — `clientContext` is now forwarded to the `loadData` call, ensuring KPI data is displayed in the correct timezone when one is configured via `clientContext`."
+    ]
+  },
+  {
+    "version": "v0.3.11",
+    "date": "2026-06-23",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.11",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.11",
+    "notes": [
+      "Added an `ignoreEmptyData` boolean sub-input to time dimensions across all time-series chart components (bar, line, area, combo, heatmap, and pivot table charts). When enabled, dates with no data are omitted from the chart rather than being gap-filled with empty data points — useful for sparse datasets where gap-filling would produce misleading zero-value intervals."
+    ]
+  },
+  {
     "version": "v0.3.9",
     "date": "2026-06-22",
     "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.9",


### PR DESCRIPTION
## Summary

Adds three new Remarkable Pro releases to the changelog, each as a separate entry.

### v0.3.13 (2026-07-01)
- Updated to Remarkable UI 3.0.21, extending the date-picker to support date selection up to five years in the future. Source: [PR #229](https://github.com/embeddable-hq/remarkable-pro/pull/229) · [GitHub release](https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.13) · [NPM](https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.13)

### v0.3.12 (2026-07-01)
- Fixed the KPI chart not respecting the viewer's timezone — `clientContext` is now forwarded to the `loadData` call. Source: [PR #227](https://github.com/embeddable-hq/remarkable-pro/pull/227) · [GitHub release](https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.12) · [NPM](https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.12)

### v0.3.11 (2026-06-23)
- Added `ignoreEmptyData` boolean sub-input to time dimensions across all time-series chart components. Source: [PR #225](https://github.com/embeddable-hq/remarkable-pro/pull/225) · [GitHub release](https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.11) · [NPM](https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.11)

Supersedes #309 (which only covered v0.3.11).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XN4RfsAoA6HM6FhfWsdC1t)_