### PR TITLE
Add Remarkable Pro v0.3.14 to changelog

### DIFF
--- a/pages/component-libraries/remarkable-pro/changelog.json
+++ b/pages/component-libraries/remarkable-pro/changelog.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "v0.3.14",
+    "date": "2026-07-03",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.14",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.14",
+    "notes": [
+      "Fixed the `EditorCard` component incorrectly applying a border style — the border is now discarded so the editor card renders without an unwanted border."
+    ]
+  },
+  {
     "version": "v0.3.13",
     "date": "2026-07-01",
     "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.13",


### PR DESCRIPTION
Adds the changelog entry for Remarkable Pro v0.3.14, released 2026-07-03.

**Change:** Fixed the `EditorCard` component incorrectly applying a border style — the border is now discarded so the editor card renders without an unwanted border.

- GitHub release: https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.14
- npm: https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.14
- Source PR: https://github.com/embeddable-hq/remarkable-pro/pull/232

---
_Generated by [Claude Code](https://claude.ai/code/session_01XR1wmsRvBhwb5ebGeamSKV)_