### PR TITLE
Add Remarkable Pro v0.3.15 to changelog

### DIFF
--- a/pages/component-libraries/remarkable-pro/changelog.json
+++ b/pages/component-libraries/remarkable-pro/changelog.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "v0.3.15",
+    "date": "2026-07-07",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.15",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.15",
+    "notes": [
+      "Pivot table row and column totals have been upgraded from simple on/off toggles to multi-select aggregation pickers — you can now independently choose which calculations (Sum, Min, Max, Average) to show on each axis. The aggregate labels displayed in the rendered table (\"Sum\", \"Min\", \"Max\", \"Average\") are now translatable via the theme i18n keys `charts.pivotTable.sum`, `charts.pivotTable.min`, `charts.pivotTable.max`, and `charts.pivotTable.average`. The sub-input labels have been renamed from \"Show row/column aggregation\" to \"Show row/column calculation\"."
+    ]
+  },
+  {
     "version": "v0.3.14",
     "date": "2026-07-03",
     "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.14",


### PR DESCRIPTION
## Summary

Adds the v0.3.15 release entry to the Remarkable Pro changelog.

**Release:** [v0.3.15](https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.15) — published 2026-07-07

**Source PR:** [#231 — Integrate updated PivotTable](https://github.com/embeddable-hq/remarkable-pro/pull/231)

### Changes in this release

- Pivot table row and column totals upgraded from simple on/off toggles to multi-select aggregation pickers (Sum, Min, Max, Average) per axis
- Aggregate labels in the rendered table are now translatable via theme i18n keys (`charts.pivotTable.sum|min|max|average`)
- Sub-input labels renamed from "Show row/column aggregation" to "Show row/column calculation"

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7sMqaUrv7Jc1cRstizwKv)_