### PR TITLE
Add Remarkable Pro v0.3.15 and v0.3.16 to changelog

### DIFF
--- a/pages/component-libraries/remarkable-pro/changelog.json
+++ b/pages/component-libraries/remarkable-pro/changelog.json
@@ -1,5 +1,23 @@
 [
   {
+    "version": "v0.3.16",
+    "date": "2026-07-08",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.16",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.16",
+    "notes": [
+      "Added a fallback for when the i18n system is not initialized — for example, when `clientContext` is not configured on `<EmbeddedComponent>`. Text values that are not translation keys are now returned as-is, and for values that are translation keys, the user's configured input field value is used as the fallback, preventing broken or empty text when i18n initialization fails due to misconfiguration."
+    ]
+  },
+  {
+    "version": "v0.3.15",
+    "date": "2026-07-07",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.15",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.15",
+    "notes": [
+      "Pivot table row and column totals have been upgraded from simple on/off toggles to multi-select aggregation pickers — each measure can now independently show any combination of Sum, Min, Max, and Average calculations per axis. The sub-input labels have been renamed from \"Show row/column aggregation\" to \"Show row/column calculation\", and the aggregate labels rendered in the table are now translatable via the theme i18n keys `charts.pivotTable.sum`, `charts.pivotTable.min`, `charts.pivotTable.max`, and `charts.pivotTable.average`."
+    ]
+  },
+  {
     "version": "v0.3.14",
     "date": "2026-07-03",
     "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.14",


### PR DESCRIPTION
## Summary

Adds the v0.3.15 and v0.3.16 release entries to the Remarkable Pro changelog.

---

### v0.3.16 — 2026-07-08

**Release:** [v0.3.16](https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.16) · [npm](https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.16)

**Source PR:** [#235 — TPS-1412: fallback for i18n not initialized](https://github.com/embeddable-hq/remarkable-pro/pull/235)

**Changes:**
- Added a fallback for when the i18n system is not initialized (e.g. missing `clientContext` on `<EmbeddableProvider>`). Text values that are not translation keys are returned as-is; for translation keys, the user's configured input field value is used as the fallback.

---

### v0.3.15 — 2026-07-07

**Release:** [v0.3.15](https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.15) · [npm](https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.15)

**Source PR:** [#231 — RUI-239: Integrate updated PivotTable](https://github.com/embeddable-hq/remarkable-pro/pull/231)

**Changes:**
- Pivot table row/column totals upgraded from on/off toggles to multi-select aggregation pickers (Sum, Min, Max, Average) per axis
- Sub-input labels renamed from "Show row/column aggregation" to "Show row/column calculation"
- Aggregate labels in the rendered table are now translatable via `charts.pivotTable.sum|min|max|average` i18n keys

---

_Supersedes [#313](https://github.com/embeddable-hq/handbook/pull/313) (v0.3.15 only)_