### PR TITLE
Add a worked example to the Time Zone section of the i18n docs

### DIFF
--- a/pages/component-libraries/remarkable-pro/i18n.mdx
+++ b/pages/component-libraries/remarkable-pro/i18n.mdx
@@ -266,6 +266,36 @@ formatter: {
 
 ## Time Zone
 
-By default, Remarkable Pro displays dates and times in UTC, but it also supports **time zone localization**, so your users can see dates and times in their local time zone. You can pass the user's [IANA time zone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) (e.g. "America/New_York") via [Client Context](/component-libraries/client-context) to have all dates and times automatically converted to that time zone.
+By default, Remarkable Pro shows dates and times in UTC, but it also supports **time zone localization**, so your users can see dates and times in their local time zone. All you need to do is pass the user's [IANA time zone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) via [Client Context](/component-libraries/client-context).
 
-Full Information and an example can be found in our documentation on [Client Context](/component-libraries/client-context#example-use-case-time-zones).
+**Example**
+
+```js
+// Your front-end code
+
+<em-beddable
+  token="${json.token}"
+  client-context="${JSON.stringify({ timezone: 'America/New_York' })}"
+></em-beddable>
+```
+
+To try out time zones in the Builder, add presets to your `client-contexts.cc.yml`:
+
+```yaml
+# src/embeddable/presets/client-contexts.cc.yml
+
+- name: New York user
+  clientContext:
+    timezone: America/New_York
+
+- name: Tokyo user
+  clientContext:
+    timezone: Asia/Tokyo
+```
+
+**Things to notice**
+
+- The value must be a valid IANA identifier (e.g. `America/New_York`, `Europe/Paris`, `Asia/Tokyo`). Invalid values are ignored, and Remarkable falls back to UTC.
+- No theme configuration is needed - Remarkable Pro picks up `clientContext.timezone` automatically.
+- The time zone is applied when data is loaded: time-based data is grouped into that zone's days, weeks and months (e.g. an event at 11pm on 16 July in New York is counted under 16 July, not 17 July UTC), and relative date ranges like `Today` or `This week` resolve to that zone's calendar boundaries.
+- To wire time zones into your own custom components, pass the time zone to `loadData` - see the example in [Client Context](/component-libraries/client-context#example-use-case-time-zones).


### PR DESCRIPTION
## What

The Time Zone section at the bottom of the Remarkable Pro i18n page was a two-line stub deferring to the Client Context page. It now matches the rest of the page's **Example + Things to notice** pattern:

- Embed-side example passing `timezone: 'America/New_York'` via the `client-context` attribute (same syntax as the Client Context page)
- `client-contexts.cc.yml` presets (New York / Tokyo) for testing time zones in the Builder
- Notes on IANA format with UTC fallback for invalid values, zero theme configuration needed, what actually changes (query-time data bucketing + relative date ranges resolving in the user's zone), and the existing cross-link for wiring custom components

## Verification

Every claim traced to the Remarkable Pro source:

- Charts receive `clientContext` directly from the SDK (third `props` arg) and pass `timezone` into `loadData` (`LineChartDefaultPro/definition.ts`), so the data path needs no theme config
- `theme.clientContext.timezone` is populated automatically: the SDK's theme-hook composition (`embeddableThemeHook.js.template` in `@embeddable.com/sdk-core`) runs the library's own theme provider (which validates and attaches the timezone via `getClientContextTimezone`) before the user's `themeProvider` receives it as `parentTheme`
- Invalid IANA strings are dropped by `getClientContextTimezone` → queries go out without a timezone (UTC) and date-range presets fall back to `dayjs.utc`
- Relative ranges (`Today`, `This week`, …) resolve via `dayjs.tz` in the target zone (`defaults.DateRanges.constants.ts`)
- `pnpm build` passes; section verified rendering in the dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)