### PR TITLE
Add changelog entries for remarkable-pro v0.3.17, v0.3.18, v0.3.19

### DIFF
--- a/pages/component-libraries/remarkable-pro/changelog.json
+++ b/pages/component-libraries/remarkable-pro/changelog.json
@@ -1,5 +1,32 @@
 [
   {
+    "version": "v0.3.19",
+    "date": "2026-07-17",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.19",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.19",
+    "notes": [
+      "Disabled the box shadow on the `EditorCard` component."
+    ]
+  },
+  {
+    "version": "v0.3.18",
+    "date": "2026-07-17",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.18",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.18",
+    "notes": [
+      "Updated the Remarkable UI dependency to the latest version, bringing the latest interface enhancements."
+    ]
+  },
+  {
+    "version": "v0.3.17",
+    "date": "2026-07-15",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.17",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.17",
+    "notes": [
+      "Added a `canBeCleared` option to `SingleSelectFieldPro` and `MultiSelectFieldPro`. When set to false, the field automatically pre-selects the first available option if no value is currently selected — ensuring these fields always have a value when clearing is disabled."
+    ]
+  },
+  {
     "version": "v0.3.16",
     "date": "2026-07-08",
     "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.16",


### PR DESCRIPTION
Adds three new changelog entries to `pages/component-libraries/remarkable-pro/changelog.json` for releases merged today and on 2026-07-15.

## Changes

**v0.3.19** (2026-07-17) — [PR #247](https://github.com/embeddable-hq/remarkable-pro/pull/247)
- Disabled the box shadow on the `EditorCard` component.

**v0.3.18** (2026-07-17) — [PR #244](https://github.com/embeddable-hq/remarkable-pro/pull/244) / [PR #245](https://github.com/embeddable-hq/remarkable-pro/pull/245)
- Updated the Remarkable UI dependency to the latest version, bringing the latest interface enhancements.

**v0.3.17** (2026-07-15) — [PR #239](https://github.com/embeddable-hq/remarkable-pro/pull/239) / [PR #240](https://github.com/embeddable-hq/remarkable-pro/pull/240)
- Added a `canBeCleared` option to `SingleSelectFieldPro` and `MultiSelectFieldPro`. When set to false, the field automatically pre-selects the first available option if no value is currently selected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdEv67Wbzko15dSWfpXW6R)_