### PR TITLE
Fix dead link: redirect bare /component-libraries/remarkable-pro

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -43,6 +43,11 @@ module.exports = withNextra({
         permanent: true,
       },
       {
+        source: "/component-libraries/remarkable-pro",
+        destination: "/component-libraries/remarkable-pro/introduction",
+        permanent: true,
+      },
+      {
         source: "/dashboards/building-dashboards",
         destination: "/dashboards/introduction",
         permanent: true,


### PR DESCRIPTION
## Problem

`https://docs.embeddable.com/component-libraries/remarkable-pro` 404s — the `remarkable-pro/` directory has no index page, only `introduction.mdx`. It's linked from ~15 docs pages, including the [legacy Vanilla Components introduction](https://docs.embeddable.com/legacy/vanilla-components/introduction) that surfaced the report.

## Fix

Add a permanent redirect from the bare path to `/component-libraries/remarkable-pro/introduction`, matching the existing pattern already used for `/dashboards/starter-components`. This resolves every internal link to the bare path at once, plus any inbound/external links.

## Verification

Tested against the local dev server:
- `/component-libraries/remarkable-pro` → `308` → `/component-libraries/remarkable-pro/introduction`
- `/component-libraries/remarkable-pro/introduction` → `200`

🤖 Generated with [Claude Code](https://claude.com/claude-code)