### PR TITLE
Add changelog entries for remarkable-pro v0.3.17–v0.3.21

### DIFF
--- a/pages/component-libraries/remarkable-pro/changelog.json
+++ b/pages/component-libraries/remarkable-pro/changelog.json
@@ -1,5 +1,50 @@
 [
   {
+    "version": "v0.3.21",
+    "date": "2026-07-22",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.21",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.21",
+    "notes": [
+      "Fixed the KPI chart comparison period label being incorrectly lowercased — the `toLowerCase()` transformation has been removed so that comparison period labels now preserve their original capitalisation."
+    ]
+  },
+  {
+    "version": "v0.3.20",
+    "date": "2026-07-20",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.20",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.20",
+    "notes": [
+      "Added `FilterBuilderWithGrouping` component — a new filter builder supporting nested AND/OR filter groups, enabling mixed-logic conditions such as `Age > 10 AND (Date is X OR Country is Y)`. Groups are Cube-safe (a group cannot mix dimensions and measures; the top-level OR is disabled when types are mixed). The new component ships alongside the existing `FilterBuilderPro`, which is unchanged, ensuring zero impact for existing customers. New additive theme tokens (`--em-filter-*`) and i18n keys are included."
+    ]
+  },
+  {
+    "version": "v0.3.19",
+    "date": "2026-07-17",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.19",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.19",
+    "notes": [
+      "Removed the box shadow from the `EditorCard` component."
+    ]
+  },
+  {
+    "version": "v0.3.18",
+    "date": "2026-07-17",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.18",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.18",
+    "notes": [
+      "Updated the Remarkable UI dependency to the latest version, bringing the latest interface enhancements."
+    ]
+  },
+  {
+    "version": "v0.3.17",
+    "date": "2026-07-15",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.17",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.17",
+    "notes": [
+      "Added a `canBeCleared` option to `SingleSelectFieldPro` and `MultiSelectFieldPro`. When set to false, the field automatically pre-selects the first available option when no value is selected and hides the clear button, preventing users from deselecting the field entirely."
+    ]
+  },
+  {
     "version": "v0.3.16",
     "date": "2026-07-08",
     "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.16",


### PR DESCRIPTION
Adds five new changelog entries to `pages/component-libraries/remarkable-pro/changelog.json` for releases merged since the last entry (v0.3.16).

## Changes

**v0.3.21** (2026-07-22) — [GitHub release](https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.21) · [npm](https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.21)
- Fixed the KPI chart comparison period label being incorrectly lowercased — the `toLowerCase()` transformation has been removed so comparison period labels now preserve their original capitalisation.

**v0.3.20** (2026-07-20) — [GitHub release](https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.20) · [npm](https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.20)
- Added `FilterBuilderWithGrouping` component — a new filter builder supporting nested AND/OR filter groups. Ships alongside the unchanged `FilterBuilderPro`; zero impact for existing customers.

**v0.3.19** (2026-07-17) — [GitHub release](https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.19) · [npm](https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.19)
- Removed the box shadow from the `EditorCard` component.

**v0.3.18** (2026-07-17) — [GitHub release](https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.18) · [npm](https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.18)
- Updated the Remarkable UI dependency to the latest version.

**v0.3.17** (2026-07-15) — [GitHub release](https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.17) · [npm](https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.17)
- Added a `canBeCleared` option to `SingleSelectFieldPro` and `MultiSelectFieldPro`. When false, the field auto-selects the first available option and hides the clear button.

> Note: supersedes PR #321, which covered only v0.3.17–v0.3.20.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEf4WWot75st48ALB6z3pc)_