### PR TITLE
Add changelog entries for remarkable-pro v0.3.17–v0.3.22

### DIFF
--- a/pages/component-libraries/remarkable-pro/changelog.json
+++ b/pages/component-libraries/remarkable-pro/changelog.json
@@ -1,5 +1,60 @@
 [
   {
+    "version": "v0.3.22",
+    "date": "2026-07-28",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.22",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.22",
+    "notes": [
+      "Added a standardised `embeddable-user-interaction` browser event that all Pro chart components dispatch on click interactions. The event fires on the `window` object and carries a consistent payload including `componentName`, an optional `trackingId`, and the clicked `dimension`, `dimensionValue`, `dimensionTimeRange`, group-by dimension, and measure values — providing a single chart-agnostic way to observe and react to user interactions across all Pro charts. An optional `trackingId` input has been added to affected chart components so specific chart instances can be identified in event listeners.",
+      "Improved click-event payload consistency: when a click resolves to a time range, `dimensionValue` is now set to `undefined` to avoid duplicating the raw value alongside `dimensionTimeRange`."
+    ]
+  },
+  {
+    "version": "v0.3.21",
+    "date": "2026-07-22",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.21",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.21",
+    "notes": [
+      "Fixed the KPI chart comparison period label being incorrectly lowercased — the `toLowerCase()` transformation has been removed so comparison period labels now preserve their original capitalisation."
+    ]
+  },
+  {
+    "version": "v0.3.20",
+    "date": "2026-07-20",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.20",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.20",
+    "notes": [
+      "Introduced `FilterBuilderWithGrouping` — a new filter builder component that supports nested AND/OR filter groups, enabling users to compose complex multi-level filter conditions. The existing `FilterBuilderPro` is unchanged and unaffected."
+    ]
+  },
+  {
+    "version": "v0.3.19",
+    "date": "2026-07-17",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.19",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.19",
+    "notes": [
+      "Removed the box shadow from the `EditorCard` component so it renders without an unwanted shadow in embedded contexts."
+    ]
+  },
+  {
+    "version": "v0.3.18",
+    "date": "2026-07-17",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.18",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.18",
+    "notes": [
+      "Updated the Remarkable UI dependency to the latest version."
+    ]
+  },
+  {
+    "version": "v0.3.17",
+    "date": "2026-07-15",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.17",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.17",
+    "notes": [
+      "Added a `canBeCleared` boolean option to `SingleSelectFieldPro` and `MultiSelectFieldPro`. When set to `false`, the clear button is hidden and the field automatically selects the first available option, preventing the user from leaving the field empty."
+    ]
+  },
+  {
     "version": "v0.3.16",
     "date": "2026-07-08",
     "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.16",


### PR DESCRIPTION
Adds six new changelog entries to `pages/component-libraries/remarkable-pro/changelog.json` for all releases since the last recorded entry (v0.3.16).

## Changes

**v0.3.22** (2026-07-28) — [GitHub release](https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.22) · [npm](https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.22)
- Added a standardised `embeddable-user-interaction` browser event that all Pro chart components dispatch on click interactions, providing a single chart-agnostic way to observe interactions across all Pro charts. An optional `trackingId` input has been added to affected chart components.
- Improved click-event payload consistency: `dimensionValue` is now `undefined` when a click resolves to a time range, to avoid duplicating the raw value alongside `dimensionTimeRange`.

**v0.3.21** (2026-07-22) — [GitHub release](https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.21) · [npm](https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.21)
- Fixed the KPI chart comparison period label being incorrectly lowercased.

**v0.3.20** (2026-07-20) — [GitHub release](https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.20) · [npm](https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.20)
- Introduced `FilterBuilderWithGrouping` — a new filter builder supporting nested AND/OR filter groups.

**v0.3.19** (2026-07-17) — [GitHub release](https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.19) · [npm](https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.19)
- Removed the box shadow from the `EditorCard` component.

**v0.3.18** (2026-07-17) — [GitHub release](https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.18) · [npm](https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.18)
- Updated the Remarkable UI dependency to the latest version.

**v0.3.17** (2026-07-15) — [npm](https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.17)
- Added `canBeCleared` boolean option to `SingleSelectFieldPro` and `MultiSelectFieldPro`.

> Note: supersedes PR #326, which covered only v0.3.17–v0.3.21. v0.3.17 has no formal GitHub release (the changeset was published to npm but no GitHub release was created).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ejtnxr5mSnirxR5mUdNbCJ)_