### PR TITLE
Fix broken Custom Data Transformation example in extending-components docs

### DIFF
--- a/pages/component-libraries/remarkable-pro/building-new-components.mdx
+++ b/pages/component-libraries/remarkable-pro/building-new-components.mdx
@@ -87,7 +87,7 @@ The `definition` file can be used to override elements of the component. It cont
 | `meta.label` | Display name in Builder | Give it a descriptive name |
 | `meta.inputs` | Available inputs in Builder | Add new inputs |
 | `meta.events` | Emitted events | Add new events or modify existing |
-| `config.props` | Data transformation | Compute values, filter or sort data |
+| `config.props` | Maps inputs to props & defines the data query | Customize the query: sort, filter, limit |
 | `config.events` | Event payloads | Transform values before emitting |
 | `preview` | The default canvas preview | Re-use the existing preview |
 | `previewConfig` | Edit the canvas preview | Show new inputs in preview |
@@ -96,10 +96,11 @@ The `definition` file can be used to override elements of the component. It cont
 
 When you only need to change behavior (not UI), you can reuse the original React component and just override the necessary parts of `definition.ts`. 
 
-This example extends the default Bar Chart, creating a new version that always sorts data descending by value:
+This example extends the default Bar Chart, creating a new version that always sorts by the first measure, descending. The sort is applied to the data query itself, so it also works correctly with the component's `Max Results` limit:
 
 ```tsx
 // definition.ts
+import { loadData } from '@embeddable.com/core';
 import { barChartDefaultPro } from '@embeddable.com/remarkable-pro';
 import { Inputs } from '@embeddable.com/react';
 
@@ -112,23 +113,21 @@ const meta = {
 const props = (
   inputs: Inputs<typeof meta>,
   stateTuple: Parameters<typeof barChartDefaultPro.config.props>[1],
+  clientContext: Parameters<typeof barChartDefaultPro.config.props>[2],
 ) => {
-  const baseProps = barChartDefaultPro.config.props(
-    inputs as Inputs<typeof barChartDefaultPro.meta>,
-    stateTuple,
-  );
+  const baseInputs = inputs as Inputs<typeof barChartDefaultPro.meta>;
+  const baseProps = barChartDefaultPro.config.props(baseInputs, stateTuple, clientContext);
 
-  // Sort data descending by first measure value
-    const measureName = inputs.measures?.[0]?.name;
-    const sortedData = [...(baseProps.results.data ?? [])].sort((a, b) => {
-        if (!measureName) return 0;
-        return (b[measureName] ?? 0) - (a[measureName] ?? 0);
-    });
+  // Sort by the first measure, descending
+  const measure = inputs.measures?.[0];
 
-    return {
+  return {
     ...baseProps,
-    results: { ...baseProps.results, data: sortedData },
-    };
+    results: loadData({
+      ...barChartDefaultPro.results.loadDataArgs(baseInputs, baseProps.dimension, clientContext),
+      orderBy: measure ? [{ property: measure, direction: 'desc' }] : undefined,
+    }),
+  };
 };
 
 export const barChartSortedDesc = {
@@ -151,8 +150,13 @@ export default defineComponent(barChartSortedDesc.Component, meta, barChartSorte
 Things to notice:
 - **Two files only** - no `index.tsx` needed since we reuse the original React component
 - **Spread the original** - `...barChartDefaultPro.meta` inherits all existing inputs, then we override `name` and `label`
-- **Call the original props function** - `barChartDefaultPro.config.props(inputs, stateTuple)` gives us the base props, which we then modify
+- **Call the original props function** - `barChartDefaultPro.config.props(inputs, stateTuple, clientContext)` gives us the base props; always pass `clientContext` through - it carries e.g. the viewer's timezone
+- **Customize the query, not the loaded rows** - `barChartDefaultPro.results.loadDataArgs(...)` returns the component's standard data request; we add `orderBy` to it and wrap it in `loadData()` again
 - **Export spreads the original** - `...barChartDefaultPro` inherits `Component`, `preview`, and anything else we don't override
+
+<Callout emoji="💡">
+`config.props` runs **before** any data has loaded: `loadData()` returns a query definition, which Embeddable executes for you, delivering the loaded rows to your React component as `results` (`{ isLoading, data, error }`). This means `results.data` is not available inside `config.props`. To transform loaded rows client-side (e.g. computed columns), wrap the React component instead (as in Example 2) and transform `props.results.data` at render time.
+</Callout>
 
 #### Example 2: Low Stock Warning
 
@@ -182,10 +186,12 @@ const meta = {
 const props = (
   inputs: Inputs<typeof meta>,
   stateTuple: Parameters<typeof barChartDefaultPro.config.props>[1],
+  clientContext: Parameters<typeof barChartDefaultPro.config.props>[2],
 ) => {
   const baseProps = barChartDefaultPro.config.props(
     inputs as Inputs<typeof barChartDefaultPro.meta>,
     stateTuple,
+    clientContext,
   );
   const { showLowStockWarning, lowStockThreshold } = inputs;
 


### PR DESCRIPTION
## Why

A user reported that [Example 1: Custom Data Transformation](https://docs.embeddable.com/component-libraries/remarkable-pro/building-new-components#example-1-custom-data-transformation) no longer works: `baseProps.results.data` is always `undefined`, `baseProps.results` contains a `dataLoader` property, and the snippet no longer compiles (missing `clientContext` parameter).

Investigation against remarkable-pro `main` and published SDK versions (2.10.7 → 2.13.8) showed:

- **The example never actually transformed data.** `loadData()` inside `config.props` returns a query placeholder (`{ requestParams, dataLoader }`) — the SDK executes the query after `props()` returns and hands the resolved `{ isLoading, data, error }` directly to the React component, wholesale replacing the prop. The example's client-side sort was silently discarded; charts rendered with unsorted platform data.
- **The compile error is new.** `config.props` gained a third `clientContext` parameter in remarkable-pro (RUI-85 timezone support, April 2026), after the example was written.

## What changed

- **Example 1** rewritten to sort server-side via `orderBy`: reuses `barChartDefaultPro.results.loadDataArgs(...)` and re-wraps in `loadData()` — the same pattern `TableChartPaginated` uses internally. Also correct with `Max Results` (sorts before the limit, not after). Heading unchanged so existing anchor links keep working.
- **New callout** explaining that `config.props` runs before data loads, and client-side row transforms belong in a component wrapper (Example 2's pattern) via `props.results.data`.
- **Example 2** updated to accept and pass through `clientContext`.
- **Definition-parts table**: `config.props` row now says "maps inputs to props & defines the data query" instead of "data transformation".

## Verification

- Both examples compile cleanly (`tsc --noEmit`, strict flags matching the boilerplate tsconfig) against published `@embeddable.com/remarkable-pro@0.3.23` + `core`/`react` 2.13.8 + React 19
- Page renders in the Nextra dev server with no MDX or console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)