### PR TITLE
Add Remarkable Pro v0.3.23, v0.3.24, and v0.3.25 to changelog

### DIFF
--- a/pages/component-libraries/remarkable-pro/changelog.json
+++ b/pages/component-libraries/remarkable-pro/changelog.json
@@ -1,5 +1,32 @@
 [
   {
+    "version": "v0.3.25",
+    "date": "2026-08-03",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.25",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.25",
+    "notes": [
+      "Fixed `syncDefaultFilters` not re-applying a previously adopted `defaultFilters` value after the filter list was cleared in `FilterBuilderPro` and `FilterBuilderWithGroupingPro`. Deleting the last filter emits `null`, which was leaving stale adoption state behind — so pushing the same clause back in from the host was silently ignored. The host can now revert to or re-push a filter set after it has been cleared, and it will be re-applied as expected."
+    ]
+  },
+  {
+    "version": "v0.3.24",
+    "date": "2026-07-31",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.24",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.24",
+    "notes": [
+      "`FilterBuilderWithGroupingPro` now dispatches `embeddable-user-interaction` events on user-driven edits at both top-level and group-level, matching `FilterBuilderPro`. Added `trackingId` input and `componentName` for consistency with other trackable components."
+    ]
+  },
+  {
+    "version": "v0.3.23",
+    "date": "2026-07-31",
+    "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.23",
+    "npm": "https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.23",
+    "notes": [
+      "Added an opt-in `syncDefaultFilters` setting to `FilterBuilderPro` and `FilterBuilderWithGroupingPro`. When enabled, the component tracks host-driven changes to its bound `defaultFilters` after mount — allowing the host to update or reset filter state at runtime (e.g. switching between or reverting to saved filter sets) without remounting the embed. When disabled (the default), behaviour is unchanged: `defaultFilters` only seeds the initial value."
+    ]
+  },
+  {
     "version": "v0.3.22",
     "date": "2026-07-28",
     "git": "https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.22",


### PR DESCRIPTION
Adds three new Remarkable Pro releases to the changelog (supersedes #333).

## v0.3.25 (2026-08-03)
- **Fix `syncDefaultFilters` re-apply after filter cleared** — Fixed `FilterBuilderPro` and `FilterBuilderWithGroupingPro` not re-applying a previously adopted `defaultFilters` value after the filter list was cleared. Deleting the last filter emits `null`, which was leaving stale adoption state behind — the host can now revert to or re-push a filter set after clearing, and it will be re-applied as expected.
- GitHub release: https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.25
- NPM: https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.25

## v0.3.24 (2026-07-31)
- **`FilterBuilderWithGroupingPro` user-interaction events** — `FilterBuilderWithGroupingPro` now dispatches `embeddable-user-interaction` events on user-driven edits at both top-level and group-level, matching `FilterBuilderPro`. Added `trackingId` input and `componentName` for consistency with other trackable components.
- GitHub release: https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.24
- NPM: https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.24

## v0.3.23 (2026-07-31)
- **`syncDefaultFilters` setting for filter builders** — Added an opt-in `syncDefaultFilters` setting to `FilterBuilderPro` and `FilterBuilderWithGroupingPro`. When enabled, the component tracks host-driven changes to `defaultFilters` after mount, allowing the host to update or reset filter state at runtime without remounting. When disabled (the default), behaviour is unchanged: `defaultFilters` only seeds the initial value.
- GitHub release: https://github.com/embeddable-hq/remarkable-pro/releases/tag/v0.3.23
- NPM: https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/0.3.23

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUCnbEWu5QMJ8kKfo7Wqao)_